### PR TITLE
Skeleton for app-service REST API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release app-service
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Parse version info from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12.9'
+
+      - name: Install build tool
+        run: pip install build
+
+      - name: Build the Python package
+        run: python -m build
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-service-${{ env.version }}
+          path: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.pytest_cache/
+**/__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.9-slim
+
+WORKDIR /root
+
+RUN apt-get update && apt-get install -y git  # Needed to install git packages from requirements.txt
+COPY . .
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python"]
+CMD ["app.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # app-service
+
+`app-service` serves as the application back-end API.
+
+## Features
+
+- [x] Fetches restaurant review sentiment predictions from `model-service` through REST requests
+  - [ ] `model-service` domain name is passed as an environment variable
+- [x] Integrates `lib-version` to display the latest version
+- [x] Automatic versioning based on Git version tag
+- [x] Automatic artifact release through a GitHub Actions workflow
+
+## API usage
+
+`api-service` exposes a REST API on port 8080 (_todo: configure `model-service` DNS name in ENV variable_).
+The following endpoints are available:
+
+### `POST`
+
+- `http://[domain]:[port]/get-prediction`
+
+  - Payload: `{"review": "some user review"}`
+  - Returns: `"positive"` or `"negative"` classification
+
+### `GET`
+
+- `http://[domain]:[port]/version`
+  
+  - Returns: latest version from `lib-version`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - [x] Fetches restaurant review sentiment predictions from `model-service` through REST requests
   - [ ] `model-service` domain name is passed as an environment variable
+- [ ] Provides an endpoint to have `model-service` update or confirm its prediction of a restaurant review's sentiment (_TODO: needs to be actually implemented, but endpoint exists_)
 - [x] Integrates `lib-version` to display the latest version
 - [x] Automatic versioning based on Git version tag
 - [x] Automatic artifact release through a GitHub Actions workflow
@@ -19,8 +20,15 @@ The following endpoints are available:
 
 - `http://[domain]:[port]/get-prediction`
 
+  - Fetches a restaurant review sentiment prediction from `model-service`. 
   - Payload: `{"review": "some user review"}`
   - Returns: `"positive"` or `"negative"` classification
+
+- `http://[domain]:[port]/update-prediction`
+
+  - Requests `model-service` to update or confirm a restaurant review sentiment prediction.
+  - Payload: `{"review": "some user review", "label": "[positive]/[negative]"}`
+  - Returns: `OK` if `model-service` could update its prediction
 
 ### `GET`
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ def get_prediction():
 		400:
 			description: Input is not a JSON object with "review" as key.
 		500:
-			description: Prediction could not be fetched.
+			description: Prediction could not be fetched from `model-service`.
 	"""
 	try:
 		msg = request.get_json()
@@ -48,6 +48,41 @@ def get_prediction():
 		return model_service_response.text
 
 	return 'Could not fetch prediction', 500
+
+
+@app.route('/update-prediction', methods=['POST'])
+def update_prediction():
+	"""
+	Updates or confirms a prediction.
+	This request is forwarded to `model-service` for processing.
+	---
+	parameters:
+	  - name: input
+	    in: body
+	    description: JSON with "review" and "label" keys.
+	    required: true
+	responses:
+		200:
+			description: Request was OK.
+		400:
+			description: Input is not in a correct format.
+		500:
+			description: Could not connect to `model-service`.
+	"""
+	try:
+		msg = request.get_json()
+	except Exception:
+		return 'Payload should be a JSON object with "review" and "label" as keys', 400
+
+	if not 'review' in msg:
+		return 'JSON payload should contain "review" key', 400
+	if not 'label' in msg:
+		return 'JSON payload should contain "label" key', 400
+
+	# Here, we would want to send a request to model-service,
+	# but for testing purposes we don't.
+	# req_url = f'http://{model_service_url}:{model_service_port}/update-prediction'
+	return f'Review label was successfully updated to {msg['label']}'
 
 
 @app.route("/version", methods=["GET"])

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+import os
+import requests
+from flask import Flask, request
+from flasgger import Swagger
+from libversion.version_util import VersionUtil
+
+app = Flask(__name__)
+swagger = Swagger(app)
+
+# Fetch URL/port to model-service from environment variables (service name from docker-compose)
+model_service_url = os.getenv('MODEL_SERVICE_URL', default='model-service')
+model_service_port = os.getenv('MODEL_SERVICE_PORT', default='8081')
+
+
+@app.route('/get-prediction', methods=['POST'])
+def get_prediction():
+	"""
+	Fetches the predicted sentiment of a restaurant review from `model-service`.
+	---
+	parameters:
+	  - name: input
+	    in: body
+	    description: JSON with 'review' key and the user review as value.
+	    required: true
+	responses:
+		200:
+			description: Prediction result ("positive" or "negative").
+		400:
+			description: Input is not a JSON object with "review" as key.
+		500:
+			description: Prediction could not be fetched.
+	"""
+	try:
+		msg = request.get_json()
+	except Exception:
+		return 'Payload should be a JSON object with "review" as key', 400
+
+	if not 'review' in msg:
+		return 'JSON payload should contain "review" key', 400
+
+	req_url = f'http://{model_service_url}:{model_service_port}/predict'
+	try:
+		model_service_response = requests.post(req_url, json=msg)
+	except Exception:
+		return f'Could not connect to model-service', 500
+
+	if model_service_response.ok:
+		return model_service_response.text
+
+	return 'Could not fetch prediction', 500
+
+
+@app.route("/version", methods=["GET"])
+def get_lib_version():
+	"""
+	Gets the version from the lib-version package.
+	---
+	responses:
+		200:
+			description: Version (v#.#.#) from lib-version.
+		500:
+			description: Version could not be retrieved.
+	"""
+	try:
+		return VersionUtil.get_version()
+	except Exception as e:
+		print(e)
+		return "Version not found", 500
+
+app.run(host="0.0.0.0", port=8080)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ['setuptools>=42']
+build-backend = 'setuptools.build_meta'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask==2.3.3
+flasgger==0.9.7.1
+requests==2.32.3
+
+libversion @ git+https://github.com/remla25-team3/lib-version@v1.0.0    # Should be changed to @main or @latest once lib-version is updated
+
+.   # Import packages inside this project

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+name = app-service
+version = 1.0.0
+description = API acting as the application back-end


### PR DESCRIPTION
Skeleton for the app-service REST API.
See `README` for existing endpoints.

The `/update-prediction` endpoint still needs to be implemented depending on our wishes of how users should interact with our app.

To properly test this API and its interaction with `model-service`, the containers should be run from e.g. the `operation` service and configured such that the domain names and ports can be set using environment variables.