### PR TITLE
chore:Add exporter for Prometheus metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,6 @@ model_service_port = os.getenv('MODEL_SERVICE_PORT', default='8081')
 
 
 ## Metrics
-num_predictions_fetched = 0		# Total number of predictions fetched by user
-times_prediction_updated = 0	# Number of times the user updated a prediction
 
 # General info
 metrics.info('app_info', 'Application info', version=VersionUtil.get_version())
@@ -30,6 +28,7 @@ prediction_count_by_type = metrics.counter(
 	'prediction_count_by_type', 'Number of predictions by type',
 	labels={'prediction': lambda response: response.text}
 )
+
 
 @app.route('/get-prediction', methods=['POST'])
 def get_prediction():
@@ -124,28 +123,5 @@ def get_lib_version():
 		print(e)
 		return "Version not found", 500
 
-
-@app.route("/metrics", methods=["GET"])
-def metrics():
-	"""
-	Endpoint for metrics inspectable in Prometheus.
-	---
-	responses:
-		200:
-			description: >
-				Plain text in Prometheus-friendly format.
-				Metrics: num_predictions_fetched (counter), times_prediction_updated (counter).
-	"""
-	global num_predictions_fetched, times_prediction_updated
-
-	m  = '# HELP num_predictions_fetched Number of predictions fetched from `model-service`.\n'
-	m += '# TYPE num_predictions_fetched counter\n'
-	m += f'num_predictions_fetched = {str(num_predictions_fetched)}\n\n'
-
-	m += '# HELP times_prediction_updated Number of times the user updated a prediction from `model-service`.\n'
-	m += '# TYPE times_prediction_updated counter\n'
-	m += f'times_prediction_updated = {str(times_prediction_updated)}\n\n'
-
-	return Response(m, mimetype='text/plain')
 
 app.run(host="0.0.0.0", port=5000)

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import requests
 from flask import Flask, request, Response
 from prometheus_flask_exporter import PrometheusMetrics
 from flasgger import Swagger
-from libversion.version_util import VersionUtil
+from libversion import version_util
 
 app = Flask(__name__)
 swagger = Swagger(app)
@@ -17,7 +17,7 @@ model_service_port = os.getenv('MODEL_SERVICE_PORT', default='8081')
 ## Metrics
 
 # General info
-metrics.info('app_info', 'Application info', version=VersionUtil.get_version())
+metrics.info('app_info', 'Application info', version=version_util.VersionUtil.get_version())
 
 review_input_length = metrics.histogram(
 	'input_length_vs_prediction', 'Histogram of review input lengths verus predictions',
@@ -53,7 +53,7 @@ def get_prediction():
 			description: Prediction could not be fetched from `model-service`.
 	"""
 	# Keep track of currently active requests
-	active_prediction_requests.inc()
+	# active_prediction_requests.inc()
 
 	try:
 		try:
@@ -75,14 +75,15 @@ def get_prediction():
 			review_input_length.observe(len(msg['review']))
 
 			# Also increment prediction count by type
-			prediction_count_by_type.inc()
+			# prediction_count_by_type.inc()
 
 			return model_service_response.text
 
 		return 'Could not fetch prediction', 500
 	finally:
 		# Request was finished; decrease number of active requests
-		active_prediction_requests.dec()
+		# active_prediction_requests.dec()
+		pass
 
 
 @app.route('/update-prediction', methods=['POST'])
@@ -129,7 +130,7 @@ def get_lib_version():
 			description: Version could not be retrieved.
 	"""
 	try:
-		return VersionUtil.get_version()
+		return version_util.VersionUtil.get_version()
 	except Exception as e:
 		print(e)
 		return "Version not found", 500

--- a/app.py
+++ b/app.py
@@ -107,6 +107,15 @@ def get_lib_version():
 
 @app.route("/metrics", methods=["GET"])
 def metrics():
+	"""
+	Endpoint for metrics inspectable in Prometheus.
+	---
+	responses:
+		200:
+			description: >
+				Plain text in Prometheus-friendly format.
+				Metrics: num_predictions_fetched (counter), times_prediction_updated (counter).
+	"""
 	global num_predictions_fetched, times_prediction_updated
 
 	m  = '# HELP num_predictions_fetched Number of predictions fetched from `model-service`.\n'
@@ -117,6 +126,6 @@ def metrics():
 	m += '# TYPE times_prediction_updated counter\n'
 	m += f'times_prediction_updated = {str(times_prediction_updated)}\n\n'
 
-	return Response('', mimetype='text/plain')
+	return Response(m, mimetype='text/plain')
 
 app.run(host="0.0.0.0", port=5000)

--- a/app.py
+++ b/app.py
@@ -64,10 +64,10 @@ def get_prediction():
 
 	if model_service_response.ok:
 		# If we got a response from `model-service`, feed the input's length to the metrics
-		review_input_length.labels(prediction=model_service_response.text).observe(len(msg['review']))
+		review_input_length.observe(len(msg['review']))
 
 		# Also increment prediction count by type
-		prediction_count_by_type.labels(prediction=model_service_response.text).inc()
+		prediction_count_by_type.inc()
 
 		return model_service_response.text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==2.3.3
 flasgger==0.9.7.1
 requests==2.32.3
+prometheus-flask-exporter==0.23.2
 
 libversion @ git+https://github.com/remla25-team3/lib-version@v1.0.0    # Should be changed to @main or @latest once lib-version is updated
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ flasgger==0.9.7.1
 requests==2.32.3
 prometheus-flask-exporter==0.23.2
 
-libversion @ git+https://github.com/remla25-team3/lib-version@v1.0.0    # Should be changed to @main or @latest once lib-version is updated
+libversion @ git+https://github.com/remla25-team3/lib-version@main
 
 .   # Import packages inside this project


### PR DESCRIPTION
Adds a dependency to `prometheus_flask_exporter` which automatically exports default metrics to a `/metrics` endpoint, which can in turn be discovered by a Prometheus service.

Also adds a simple counter, gauge, and histogram metric.